### PR TITLE
DOC: Fixed incorrect link in blosc.py

### DIFF
--- a/src/zarr/codecs/blosc.py
+++ b/src/zarr/codecs/blosc.py
@@ -55,7 +55,7 @@ class BloscCname(Enum):
     zlib = "zlib"
 
 
-# See https://zarr.readthedocs.io/en/stable/tutorial.html#configuring-blosc
+# See https://zarr.readthedocs.io/en/stable/user-guide/performance.html#configuring-blosc
 numcodecs.blosc.use_threads = False
 
 


### PR DESCRIPTION
The "see more" under BloscCname class contains [old link](https://zarr.readthedocs.io/en/stable/tutorial.html#configuring-blosc) to refer more information about configuring Blosc but it is currently shifted to [new link](https://zarr.readthedocs.io/en/stable/user-guide/performance.html#configuring-blosc)